### PR TITLE
Friction ratio units

### DIFF
--- a/lib/__tests__/measures.test.js
+++ b/lib/__tests__/measures.test.js
@@ -44,6 +44,7 @@ test('measures', () => {
       'lineVolume',
       'resistance',
       'torqueConversionFactor',
+      'frictionRatio',
     ];
   expect(actual.sort()).toEqual(expected.sort());
 });

--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -351,6 +351,12 @@ test('torque conversion factor possibilities', () => {
   expect(actual.sort()).toEqual(expected.sort());
 });
 
+test('friction ratio possibilities', () => {
+  var actual = convert().possibilities('frictionRatio'),
+    expected = ['N/Pa', 'N/bar'];
+  expect(actual.sort()).toEqual(expected.sort());
+});
+
 test('all possibilities', () => {
   var actual = convert().possibilities(),
     // Please keep these sorted for maintainability
@@ -374,6 +380,8 @@ test('all possibilities', () => {
       'MPa',
       'Mb',
       'N',
+      'N/Pa',
+      'N/bar',
       'Nm/deg',
       'Nm/rad',
       'Nms/deg',

--- a/lib/definitions/__tests__/frictionRatio.test.js
+++ b/lib/definitions/__tests__/frictionRatio.test.js
@@ -1,0 +1,13 @@
+const convert = require('../..');
+
+test('N/Pa to N/Pa', () => {
+  expect(convert(1).from('N/Pa').to('N/Pa')).toBe(1);
+});
+
+test('N/Pa to N/bar', () => {
+  expect(convert(1).from('N/Pa').to('N/bar')).toBeCloseTo(1e5);
+});
+
+test('N/bar to N/Pa', () => {
+  expect(convert(1).from('N/bar').to('N/Pa')).toBeCloseTo(1e-5);
+});

--- a/lib/definitions/frictionRatio.js
+++ b/lib/definitions/frictionRatio.js
@@ -1,0 +1,26 @@
+var frictionRatio = {
+  'N/Pa': {
+    name: {
+      singular: 'Newton per Pascal',
+      plural: 'Newtons per Pascal',
+    },
+    to_anchor: 1,
+  },
+  'N/bar': {
+    name: {
+      singular: 'Newton per bar',
+      plural: 'Newtons per bar',
+    },
+    to_anchor: 1e-5,
+  },
+};
+
+module.exports = {
+  metric: frictionRatio,
+  _anchors: {
+    metric: {
+      unit: 'N/Pa',
+      ratio: 1,
+    },
+  },
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,8 @@ var convert,
     fluidViscosity: require('./definitions/fluidViscosity'),
     lineVolume: require('./definitions/lineVolume'),
     resistance: require('./definitions/resistance'),
-    torqueConversionFactor: require('./definitions/torqueConversionFactor')
+    torqueConversionFactor: require('./definitions/torqueConversionFactor'),
+    frictionRatio: require('./definitions/frictionRatio'),
   },
   Converter;
 


### PR DESCRIPTION
Added new measure and unit conversions for friction ratio as required by https://github.com/IPG-Automotive-UK/ngd/pull/520.

* Friction Ratio - N/Pa, N/bar

