### PR TITLE
TD-2435: Added new Unit for bugfix

### DIFF
--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -593,11 +593,20 @@ test('all possibilities', () => {
   expect(actual.sort()).toEqual(expected.sort());
 });
 
-test('all possibilities for m3/s*Pa', () => {
-  var actual = convert().from("m3/s*Pa").possibilities(),
-    // Please keep these sorted for maintainability
-    expected = [
-      'm3/s*Pa', 'cm3/s*bar', 'm3/s*bar'
-    ];
-  expect(actual.sort()).toEqual(expected.sort());
-});
+/**
+ * Test that adding a new unit returns the updated list of units available
+ */
+describe("Unit tests for newly added m3/s*bar unit", () => {
+  test('all possibilities for m3/s*Pa should now include new unit', () => {
+    var actual = convert().from("m3/s*Pa").possibilities(),
+      // Please keep these sorted for maintainability
+      expected = [
+        'm3/s*Pa', 'cm3/s*bar', 'm3/s*bar'
+      ];
+    expect(actual.sort()).toEqual(expected.sort());
+  });
+  test("This unit can be converted with the correct value", () => {
+    // 1 bar = 100,000 Pa so 5 m3/s*bar should equal 500,000 m3/s*Pa
+    expect(convert(5).from("m3/s*bar").to("m3/s*Pa")).toEqual(500000)
+  })
+})

--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -592,3 +592,12 @@ test('all possibilities', () => {
     ];
   expect(actual.sort()).toEqual(expected.sort());
 });
+
+test('all possibilities for m3/s*Pa', () => {
+  var actual = convert().from("m3/s*Pa").possibilities(),
+    // Please keep these sorted for maintainability
+    expected = [
+      'm3/s*Pa', 'cm3/s*bar', 'm3/s*bar'
+    ];
+  expect(actual.sort()).toEqual(expected.sort());
+});

--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -509,6 +509,7 @@ test('all possibilities', () => {
       'm3/min',
       'm3/s',
       'm3/s*Pa',
+      "m3/s*bar",
       'mA',
       'mC',
       'mcg',

--- a/lib/definitions/airwayConductance.js
+++ b/lib/definitions/airwayConductance.js
@@ -18,7 +18,7 @@ var airwayConductance = {
       singular: 'Cubic meter per second per bar',
       plural: 'Cubic meters per second per bar',
     },
-    to_anchor: 1e-5,
+    to_anchor: 1e+5,
   },
 };
 

--- a/lib/definitions/airwayConductance.js
+++ b/lib/definitions/airwayConductance.js
@@ -13,6 +13,13 @@ var airwayConductance = {
     },
     to_anchor: 1e-11,
   },
+  'm3/s*bar': {
+    name: {
+      singular: 'Cubic meter per second per bar',
+      plural: 'Cubic meters per second per bar',
+    },
+    to_anchor: 1e-5,
+  },
 };
 
 module.exports = {


### PR DESCRIPTION
Contributes to [TD-2435](https://sce.myjetbrains.com/youtrack/issue/TD-2435/Vehicle-Info-File-Importer-wrong-unit-identified)

## Changes

- Added a new unit so that VIRTO.DATA can do a unit conversion based on this new unit

## Description
- The unit has been added with the correct conversion factor
- Tests have been added so that we can get the correct unit possibility list and the the correct value is converted

## Dependencies

N/A

## UI/UX

N/A

## Future Notes
This is the first PR of 2. We are updating a util package here which we can provide to VIRTO.DATA. In the second PR, we can see the visual changes that this bug will fix. I havent been able to test this change with VIRO.DATA however, so it may be the case that we come back to this repo to make more changes  but I dont think so.

## Testing notes

This PR will test the code that I have introduced so that should be suffice. __Note:__ We need to make a conversion from this new unit `m3/s/bar` into the desired the unit which is `m3/s/Pa`. There are 100,000 Pa = 1 bar and I have written a test to make this is what's tested. 

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker. (N/A)
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
