### PR TITLE
TD-2811 Update convert units for moment of inertia 

### DIFF
--- a/lib/__tests__/measures.test.js
+++ b/lib/__tests__/measures.test.js
@@ -45,6 +45,7 @@ test('measures', () => {
       'resistance',
       'torqueConversionFactor',
       'frictionRatio',
+      'inertia',
     ];
   expect(actual.sort()).toEqual(expected.sort());
 });

--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -357,6 +357,12 @@ test('friction ratio possibilities', () => {
   expect(actual.sort()).toEqual(expected.sort());
 });
 
+test('inertia possibilities', () => {
+  var actual = convert().possibilities('inertia'),
+    expected = ['kg*m2', 'kg*mm2', 'lbf*ft*s2', 'lbf*in*s2'];
+  expect(actual.sort()).toEqual(expected.sort());
+});
+
 test('all possibilities', () => {
   var actual = convert().possibilities(),
     // Please keep these sorted for maintainability
@@ -468,6 +474,8 @@ test('all possibilities', () => {
       'kg/l',
       'kg/m3',
       'kgf/m',
+      'kg*m2',
+      'kg*mm2',
       'kkp',
       'kJ',
       'kN',
@@ -497,6 +505,8 @@ test('all possibilities', () => {
       'l/s',
       'lb',
       'lbf',
+      'lbf*ft*s2',
+      'lbf*in*s2',
       'lx',
       'm',
       'mi/h',
@@ -509,7 +519,7 @@ test('all possibilities', () => {
       'm3/min',
       'm3/s',
       'm3/s*Pa',
-      "m3/s*bar",
+      'm3/s*bar',
       'mA',
       'mC',
       'mcg',
@@ -597,17 +607,15 @@ test('all possibilities', () => {
 /**
  * Test that adding a new unit returns the updated list of units available
  */
-describe("Unit tests for newly added m3/s*bar unit", () => {
+describe('Unit tests for newly added m3/s*bar unit', () => {
   test('all possibilities for m3/s*Pa should now include new unit', () => {
-    var actual = convert().from("m3/s*Pa").possibilities(),
+    var actual = convert().from('m3/s*Pa').possibilities(),
       // Please keep these sorted for maintainability
-      expected = [
-        'm3/s*Pa', 'cm3/s*bar', 'm3/s*bar'
-      ];
+      expected = ['m3/s*Pa', 'cm3/s*bar', 'm3/s*bar'];
     expect(actual.sort()).toEqual(expected.sort());
   });
-  test("This unit can be converted with the correct value", () => {
+  test('This unit can be converted with the correct value', () => {
     // 1 bar = 100,000 Pa so 5 m3/s*bar should equal 500,000 m3/s*Pa
-    expect(convert(5).from("m3/s*bar").to("m3/s*Pa")).toEqual(500000)
-  })
-})
+    expect(convert(5).from('m3/s*bar').to('m3/s*Pa')).toEqual(500000);
+  });
+});

--- a/lib/__tests__/possibilities.test.js
+++ b/lib/__tests__/possibilities.test.js
@@ -359,7 +359,7 @@ test('friction ratio possibilities', () => {
 
 test('inertia possibilities', () => {
   var actual = convert().possibilities('inertia'),
-    expected = ['kg*m2', 'kg*mm2', 'lbf*ft*s2', 'lbf*in*s2'];
+    expected = ['kgm2', 'kgmm2', 'lbffts2', 'lbfins2'];
   expect(actual.sort()).toEqual(expected.sort());
 });
 
@@ -474,8 +474,8 @@ test('all possibilities', () => {
       'kg/l',
       'kg/m3',
       'kgf/m',
-      'kg*m2',
-      'kg*mm2',
+      'kgm2',
+      'kgmm2',
       'kkp',
       'kJ',
       'kN',
@@ -505,8 +505,8 @@ test('all possibilities', () => {
       'l/s',
       'lb',
       'lbf',
-      'lbf*ft*s2',
-      'lbf*in*s2',
+      'lbffts2',
+      'lbfins2',
       'lx',
       'm',
       'mi/h',

--- a/lib/definitions/__tests__/inertia.test.js
+++ b/lib/definitions/__tests__/inertia.test.js
@@ -1,0 +1,64 @@
+const convert = require('../..');
+test('kgm2 to kgm2', () => {
+  expect(convert(1).from('kgm2').to('kgm2')).toBe(1);
+});
+
+test('kgmm2 to kgmm2', () => {
+  expect(convert(1).from('kgmm2').to('kgmm2')).toBe(1);
+});
+
+test('lbffts2 to lbffts2', () => {
+  expect(convert(1).from('lbffts2').to('lbffts2')).toBe(1);
+});
+
+test('lbfins2 to lbfins2', () => {
+  expect(convert(1).from('lbfins2').to('lbfins2')).toBe(1);
+});
+
+test('kgm2 to kgmm2', () => {
+  expect(convert(1).from('kgm2').to('kgmm2')).toBe(1000000);
+});
+
+test('kgm2 to lbffts2', () => {
+  expect(convert(1).from('kgm2').to('lbffts2')).toBeCloseTo(0.737562);
+});
+
+test('kgm2 to lbfins2', () => {
+  expect(convert(1).from('kgm2').to('lbfins2')).toBeCloseTo(8.85074);
+});
+
+test('kgmm2 to kgm2', () => {
+  expect(convert(1).from('kgmm2').to('kgm2')).toBe(0.000001);
+});
+
+test('kgmm2 to lbffts2', () => {
+  expect(convert(1).from('kgmm2').to('lbffts2')).toBeCloseTo(7.37562e-10);
+});
+
+test('kgmm2 to lbfins2', () => {
+  expect(convert(1).from('kgmm2').to('lbfins2')).toBeCloseTo(8.85074e-9);
+});
+
+test('lbffts2 to kgm2', () => {
+  expect(convert(1).from('lbffts2').to('kgm2')).toBeCloseTo(1.355817);
+});
+
+test('lbffts2 to kgmm2', () => {
+  expect(convert(1).from('lbffts2').to('kgmm2')).toBeCloseTo(1355817.9619);
+});
+
+test('lbffts2 to lbfins2', () => {
+  expect(convert(1).from('lbffts2').to('lbfins2')).toBe(12);
+});
+
+test('lbfins2 to kgm2', () => {
+  expect(convert(1).from('lbfins2').to('kgm2')).toBeCloseTo(0.11298483);
+});
+
+test('lbfins2 to kgmm2', () => {
+  expect(convert(1).from('lbfins2').to('kgmm2')).toBeCloseTo(112984.83);
+});
+
+test('lbfins2 to lbffts2', () => {
+  expect(convert(1).from('lbfins2').to('lbffts2')).toBeCloseTo(0.0833333);
+});

--- a/lib/definitions/inertia.js
+++ b/lib/definitions/inertia.js
@@ -1,0 +1,50 @@
+var metric, imperial;
+
+metric = {
+  'kg*m2': {
+    name: {
+      singular: 'Kilogram meter squared',
+      plural: 'Kilogram meters squared',
+    },
+    to_anchor: 1,
+  },
+  'kg*mm2': {
+    name: {
+      singular: 'Kilogram millimeter squared',
+      plural: 'Kilogram millimeters squared',
+    },
+    to_anchor: 0.000001,
+  },
+};
+
+imperial = {
+  'lbf*ft*s2': {
+    name: {
+      singular: 'Pound foot second squared',
+      plural: 'Pound feet second squared',
+    },
+    to_anchor: 1,
+  },
+  'lbf*in*s2': {
+    name: {
+      singular: 'Pound inch second squared',
+      plural: 'Pound inches second squared',
+    },
+    to_anchor: 12,
+  },
+};
+
+module.exports = {
+  metric: metric,
+  imperial: imperial,
+  _anchors: {
+    metric: {
+      unit: 'kg*m2',
+      ratio: 1 / 1.3558179619,
+    },
+    imperial: {
+      unit: 'lbf*ft*s2',
+      ratio: 1.3558179619,
+    },
+  },
+};

--- a/lib/definitions/inertia.js
+++ b/lib/definitions/inertia.js
@@ -1,14 +1,14 @@
 var metric, imperial;
 
 metric = {
-  'kg*m2': {
+  kgm2: {
     name: {
       singular: 'Kilogram meter squared',
       plural: 'Kilogram meters squared',
     },
     to_anchor: 1,
   },
-  'kg*mm2': {
+  kgmm2: {
     name: {
       singular: 'Kilogram millimeter squared',
       plural: 'Kilogram millimeters squared',
@@ -18,14 +18,14 @@ metric = {
 };
 
 imperial = {
-  'lbf*ft*s2': {
+  lbffts2: {
     name: {
       singular: 'Pound foot second squared',
       plural: 'Pound feet second squared',
     },
     to_anchor: 1,
   },
-  'lbf*in*s2': {
+  lbfins2: {
     name: {
       singular: 'Pound inch second squared',
       plural: 'Pound inches second squared',
@@ -39,11 +39,11 @@ module.exports = {
   imperial: imperial,
   _anchors: {
     metric: {
-      unit: 'kg*m2',
+      unit: 'kgm2',
       ratio: 1 / 1.3558179619,
     },
     imperial: {
-      unit: 'lbf*ft*s2',
+      unit: 'lbffts2',
       ratio: 1.3558179619,
     },
   },

--- a/lib/definitions/inertia.js
+++ b/lib/definitions/inertia.js
@@ -30,7 +30,7 @@ imperial = {
       singular: 'Pound inch second squared',
       plural: 'Pound inches second squared',
     },
-    to_anchor: 12,
+    to_anchor: 1 / 12,
   },
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+const inertia = require('./definitions/inertia');
+
 var convert,
   keys = require('lodash.keys'),
   each = require('lodash.foreach'),
@@ -44,6 +46,7 @@ var convert,
     resistance: require('./definitions/resistance'),
     torqueConversionFactor: require('./definitions/torqueConversionFactor'),
     frictionRatio: require('./definitions/frictionRatio'),
+    inertia: require('./definitions/inertia'),
   },
   Converter;
 


### PR DESCRIPTION
Contributes to [TD-2811](https://sce.myjetbrains.com/youtrack/agiles/115-26/current?issue=TD-2811), [TD-2672](https://sce.myjetbrains.com/youtrack/issue/TD-2672/Support-multiple-GFCP-files-in-a-single-folder-to-be-uploaded-to-VIRTO.DATA)

## Changes

- Adds support for converting between units for moment of inertia. 
- Following units are now supported kg\*m^2, kg\*mm^2, lbf\*ft\*s^2 and lbf\*in\*s^2
- Updated existing test to include the units above. 

These updates are needed for the [TD-2672](https://sce.myjetbrains.com/youtrack/issue/TD-2672/Support-multiple-GFCP-files-in-a-single-folder-to-be-uploaded-to-VIRTO.DATA ) story as Porsche uses kgmm^2 as a unit for moment of inertia.


## Dependencies
When this PR is approved, a new release of covert-units has to be made and VIRTO.DATA and carmaker composer has to be updated to use the updated package. 

## UI/UX

N/A

## Testing notes

Check that existing tests are passing. If the reviewer wants to verify conversion factors between units they can use the following online [converter ](https://www.unitconverters.net/moment-of-inertia-converter.html)that supports inertia 

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
